### PR TITLE
Fix TokenMismatchException on session timeout

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -45,6 +45,14 @@ class Handler extends ExceptionHandler
      */
     public function render($request, Exception $e)
     {
+        if ($e instanceof \Illuminate\Session\TokenMismatchException) {
+
+            return redirect()
+                ->back()
+                ->withInput($request->except('_token'))
+                ->with('error', 'Session Expired. Please try again');
+
+        }
         return parent::render($request, $e);
     }
 }


### PR DESCRIPTION
The app throws a TokenMismatchException when a user tries to update profile when session has timed out. This PR handles this gracefully.